### PR TITLE
feat : 접근성 대응, 반복되는 영역 건너띄기 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,8 @@ import className from "@/constants/className";
 import Header from "@/components/molecules/Layouts/Header";
 import Footer from "@/components/molecules/Layouts/Footer";
 
+import DirectLink from "@/components/molecules/DirectLink";
+
 import { GoogleAnalytics } from '@next/third-parties/google'
 
 const notoSansKr = Noto_Sans_KR({
@@ -80,6 +82,7 @@ export default function RootLayout({
       <body className={ `${notoSansKr.className}` }>
         <Providers>
           <div className="wrapper">
+            <DirectLink />
             <Header />
             <div className="content">
               <article>

--- a/src/components/molecules/DirectLink/DirectLink.module.scss
+++ b/src/components/molecules/DirectLink/DirectLink.module.scss
@@ -1,0 +1,24 @@
+.dir-link {
+  position: relative;
+  z-index: 3000
+}
+
+.dir-link a {
+  position: absolute;
+  top: -30px;
+  left: 0;
+  width: 138px;
+  border: 1px solid var(--color-white);
+  background: var(--color-deep-gray);
+  text-align: center;
+  opacity: 0
+}
+
+.dir-link a:focus,
+.dir-link a:active {
+  top: 0;
+  text-decoration: none;
+  z-index: 1000;
+  opacity: 1;
+  color: var(--color-white);
+}

--- a/src/components/molecules/DirectLink/DirectLink.tsx
+++ b/src/components/molecules/DirectLink/DirectLink.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+// @ name : DirectLink
+// @ description : 반복되는 컨텐츠 스킵을 제공하는 접근성 컴포넌트
+
+import s from './DirectLink.module.scss';
+
+import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+interface HeadingProps {
+  id: string;
+  text: string;
+}
+
+const DirectLink = () => {
+
+  const pathname = usePathname(),
+        [dirLink, setDirLink] = useState<HeadingProps[]>([]);
+
+  useEffect(() => {
+
+    const headingList:HeadingProps[] = [];
+
+    document.querySelectorAll<HTMLElement>('h1, h2, h3').forEach((e) => {
+      if(! e.id) {
+        e.id = crypto.randomUUID();
+      }
+
+      const heading = {
+        id: e.id,
+        text: e.innerText
+      }
+
+      headingList.push(heading);
+    })
+
+    setDirLink(headingList);
+
+  }, [pathname]);
+
+  return (
+    <div className={ classNames( s['dir-link'] ) }>
+      {
+        dirLink.map((e: HeadingProps) => (
+          <a key={ e.id }
+             href={ `#${ e.id }` }>
+            { e.text } 바로 가기
+          </a>
+        ))
+      }
+    </div>
+  )
+}
+
+export default DirectLink;

--- a/src/components/molecules/DirectLink/index.tsx
+++ b/src/components/molecules/DirectLink/index.tsx
@@ -1,0 +1,2 @@
+
+export { default } from './DirectLink';


### PR DESCRIPTION
## 개요
웹 접근성 지침에 근거, 반복되는 요소를 스킵할 수 있는 네비게이션을 제공합니다.

## 설계 
반복되는 요소를 스킵할 수 있는 네비게이션은 레이아웃의 최상단에 위치해야하므로
클라이언트 컴포넌트로 구성하여 동적 생성합니다.

![이미지](https://github.com/user-attachments/assets/98102ce5-3f95-40a8-b433-682371e2734a)