### PR TITLE
feat : 웹 접근성 대응, 모달 컴포넌트 포커스 트랩 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
-# nklcb
+# nklcb.net
+
+<img width="800" alt="Frame 38" src="https://github.com/user-attachments/assets/9b8534e1-40e9-44e6-9075-543a986a3e7d" />
+
+배포 URL : [https://nklcb.net](https://nklcb.net)
+
+<br />
+
+## 개요
+
+- 네카라쿠배는 대한민국 IT 업계 선두 기업을 은어로 하는 네이버, 카카오, 라인, 쿠팡, 배달의민족, 당근마켓, 토스의 채용 공고를 모아 놓은 페이지 개발 프로젝트입니다. 
+- 스케줄러에 등록된 환경에 의해 매일 오전 2시, 오후 2시에 크롤링된 공고를 송출합니다.
+
+<br />
+
+## 개발 환경
+
+- Front-end : Next.js, Tanstack Query, Zustand, React-hook-form, zod, Sass
+- Back-end : Python, Gemini, Mongo DB, Next.js API Route
+- 디자인 : Figma
+- 배포 환경 : Vercel
+
+
+<br />
+
+## 공개 범위
+
+#### 공개되는 정보
+
+공개되는 정보 범위는 아래와 같습니다.
+
+- Front-end : 폴더 구조, 디자인 패턴, 상태 관리 등
+- 디자인 : 전체
+
+<br />
+
+#### 공개되지 않는 정보
+
+민감 정보, 웹 크롤러, API에 대한 정보는 공개되지 않습니다.
+
+<br />
+
+## 의존성 목록
+
+프로젝트 개발에 사용된 의존성 목록 리스트입니다.
+
+| 의존성명 | 버전 | 비고 |
+| --- | --- | --- |
+| Next.js | 15.3.0 | - |
+| Zustand | 5.0.3 | 전역 상태 관리를 위한 라이브러리 |
+| react-query | 5.69.0 | 상태 및 캐싱 관리를 위한 라이브러리 |
+| zod | 3.24.2 | 유효성 검증을 위한 라이브러리 |
+| React-hook-form | 7.55.0 | 유효성 검증을 위한 라이브러리 |
+| Sass | 1.85.1 | 디자인 시스템 관리를 위한 라이브러리 |
+
+
+<br />
+
+## 예정 사항
+
+추후 서비스 확장 여부에 따라 OAuth 로그인, 커뮤니티, 로그인 식별자에 따른 스크랩 공고 리스트, 캘린더를 제공 예정입니다.
+
+<br />
+
+## 문의
+
+프로젝트에 대한 문의는 아래를 통해 연락 바랍니다.
+- 이메일 : dobby200ok@gmail.com
+- 카카오톡 채널 : [바로가기](http://pf.kakao.com/_cxmxmnn/chat)

--- a/src/components/molecules/DynamicModal/FocusTrapDynamicModal.tsx
+++ b/src/components/molecules/DynamicModal/FocusTrapDynamicModal.tsx
@@ -1,0 +1,64 @@
+// @ name : FocusTrapDynamicModal
+// @ description : 다이나믹 모달이 활성화되었을 때, 자식으로 전달받는 children에
+//                 대화형 컨텐츠가 있는 경우 포커스 트랩을 활성화합니다.
+
+'use client';
+
+import { useRef, useEffect, ReactNode } from "react";
+import useModal from "@/hooks/useDynamicModal";
+
+interface FocusTrapDynamicModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+const FocusTrapDynamicModal:React.FC<FocusTrapDynamicModalProps> = ({ children }) => {
+
+  const focusContainer = useRef<HTMLDivElement>(null),
+        activeIndex = useRef<number | null>(null),
+        { hide } = useModal();
+
+  useEffect(() => {
+
+      const container = focusContainer.current;
+
+      if (!container) return;
+
+      const beforeHandlerElement = document.activeElement as HTMLElement,
+            interactiveContents = container.querySelectorAll<HTMLElement>('a[href], button:not([disabled]), textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex]:not([tabindex="-1"])');
+
+      const handleTabKeydownEvent = (event : KeyboardEvent) => {
+
+        if(event.key === 'Tab') {
+
+          event.preventDefault();
+
+          const next = activeIndex.current ===  null ? 0 : event.shiftKey ? activeIndex.current - 1 : activeIndex.current + 1,
+                max = interactiveContents.length - 1,
+                tabIndex = next < 0 ? max : next > max ? 0 : next;
+
+          activeIndex.current = tabIndex;
+          interactiveContents[tabIndex]?.focus();
+
+        }
+
+        if(event.key === 'Escape') {
+          hide();
+          beforeHandlerElement.focus();
+        }
+      }
+
+      document.addEventListener('keydown', handleTabKeydownEvent);
+
+      return() => document.removeEventListener('keydown', handleTabKeydownEvent);
+
+  }, []);
+
+  return (
+    <div style={{ height: '100%' }}
+         ref={focusContainer}>
+      { children }
+    </div>
+  )
+}
+
+export default FocusTrapDynamicModal;

--- a/src/components/molecules/DynamicModal/SearchModal/SearchModal.tsx
+++ b/src/components/molecules/DynamicModal/SearchModal/SearchModal.tsx
@@ -44,6 +44,7 @@ const SearchModal = () => {
                         height={ 32 }
                         fill='#bebebe' />
             <input {...register('keyword')}
+                   type="text"
                    className={ classNames( s['inp-txt'] ) }
                    placeholder='검색어를 입력해 주세요.' />
           </label>

--- a/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
+++ b/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
@@ -6,6 +6,8 @@
 
 import s from './DynamicModal.module.scss';
 import { useState, useEffect, useRef, ReactNode } from "react";
+import { useResize } from '@/hooks/useResize';
+import FocusTrapDynamicModal from './FocusTrapDynamicModal';
 
 import classNames from "classnames";
 
@@ -19,11 +21,12 @@ const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, 
 
   const [renderComplated, setRenderComplated] = useState<boolean>(false),
         [size, setSize] = useState<{ width: number, height: number | string}>({ width: 112, height: 24 }),
-        virtualDOM = useRef<HTMLDivElement>(null);
+        virtualDOM = useRef<HTMLDivElement>(null),
+        { innerSize } = useResize();
 
   useEffect(() => {
     setRenderComplated(false);
-  }, [type, children]);
+  }, [type, children, innerSize]);
 
   useEffect(() => {
     if (! renderComplated && virtualDOM.current) {
@@ -57,7 +60,7 @@ const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, 
             }}>
         <div className={ classNames( s['dynamic-modal__inner'], (active && renderComplated) && s['dynamic-modal__inner--active'] ) }>
           {
-            ( active && renderComplated ) && children
+            ( active && renderComplated ) && <FocusTrapDynamicModal>{ children }</FocusTrapDynamicModal>
           }
         </div>
       </div>

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -14,7 +14,7 @@ interface SizeProps {
 export const useResize = (optimization: 'debounce' | 'throttle' = 'debounce', time: number = 300) => {
 
   const isClient = typeof window !== 'undefined',
-        [size, setSize] = useState<SizeProps>({ 
+        [innerSize, setInnerSize] = useState<SizeProps>({ 
           width: isClient ? window.innerWidth : 0,
           height: isClient ? window.innerHeight : 0
         });
@@ -24,7 +24,7 @@ export const useResize = (optimization: 'debounce' | 'throttle' = 'debounce', ti
     if(! isClient) return;
 
     const handleResize = () => {
-      setSize({
+      setInnerSize({
         width: window.innerWidth,
         height: window.innerHeight
       })
@@ -39,7 +39,7 @@ export const useResize = (optimization: 'debounce' | 'throttle' = 'debounce', ti
 
   }, []);
 
-  return { size };
+  return { innerSize };
 }
 
 // @ name : useMobileCheck
@@ -47,8 +47,8 @@ export const useResize = (optimization: 'debounce' | 'throttle' = 'debounce', ti
 
 export const useMobileCheck = () => {
 
-  const { size } = useResize();
+  const { innerSize } = useResize();
 
-  return size.width < breakPoint.desktop;
+  return innerSize.width < breakPoint.desktop;
 
 }


### PR DESCRIPTION
## 개요
웹 접근성 지침에 근거, 모달 컴포넌트가 활성화될 때 모달 컴포넌트 하위의 대화형 컨텐츠에만 포커싱이 갈 수 있도록 조정합니다.

## 설계 
포커스 트랩을 구현하여, 모달 컴포넌트가 활성화 시 eventListner keydown의 Tab에 이벤트를 부여합니다.

## 추가 사항
다이나믹 모달의 사이즈가 부여된 후, 리사이징 이벤트가 발생 시 디바운싱을 적용하여 추가 사이즈를 부여합니다.