### PR TITLE
fix : iOS Safari Scroll 이벤트 시 resize 이벤트 트리거 충돌 수정

### DIFF
--- a/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
+++ b/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
@@ -22,11 +22,19 @@ const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, 
   const [renderComplated, setRenderComplated] = useState<boolean>(false),
         [size, setSize] = useState<{ width: number, height: number | string}>({ width: 112, height: 24 }),
         virtualDOM = useRef<HTMLDivElement>(null),
+        [windowInnerWidth, setWindowInnerWidth] = useState<number>(0),
         { innerSize } = useResize();
 
   useEffect(() => {
     setRenderComplated(false);
-  }, [type, children, innerSize]);
+  }, [type, children]);
+
+  useEffect(() => {
+    if(innerSize.width !== windowInnerWidth) {
+      setWindowInnerWidth(innerSize.width);
+      setRenderComplated(false);
+    }
+  }, [innerSize])
 
   useEffect(() => {
     if (! renderComplated && virtualDOM.current) {


### PR DESCRIPTION
## 개요
이전 PR : https://github.com/dobby200ok/nklcb.net/pull/4
에서 발생된 사이드 이펙트, iOS Safari 브라우저에서 Scroll 이벤트 발생 시 resize 이벤트가 충돌됨에 따라
다이나믹 모달이 애니메이션이 지속 호출되는 것을 방지합니다.

## 설계 
resize시, 이전 Resize 값을 가지고 있는 state값과 갱신되는 값을 비교하여 다이나믹 모달의 재렌더 이벤트를 발생시킵니다.