### PR TITLE
fix : 공고 상세 페이지 포커스트랩 오류 수정

### DIFF
--- a/src/components/molecules/DynamicModal/DynamicModal.tsx
+++ b/src/components/molecules/DynamicModal/DynamicModal.tsx
@@ -41,7 +41,8 @@ const DynamicModal = () => {
            onClick={() => hideModal()} />
       {/* 다이나믹 모달 */}
       <VirtualDynamicModal active={ active }
-                           type={ type }>
+                           type={ type }
+                           focusTrap={ dimmed ? true : false }>
         {/* 헤더 */}
         {
           title &&

--- a/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
+++ b/src/components/molecules/DynamicModal/VirtualDynamicModal.tsx
@@ -14,10 +14,11 @@ import classNames from "classnames";
 interface VirtualDynamicModalProps {
   active: boolean;
   type: string;
+  focusTrap: boolean;
   children: ReactNode;
 }
 
-const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, children }) => {
+const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, focusTrap, children }) => {
 
   const [renderComplated, setRenderComplated] = useState<boolean>(false),
         [size, setSize] = useState<{ width: number, height: number | string}>({ width: 112, height: 24 }),
@@ -60,7 +61,9 @@ const VirtualDynamicModal:React.FC<VirtualDynamicModalProps> = ({ active, type, 
             }}>
         <div className={ classNames( s['dynamic-modal__inner'], (active && renderComplated) && s['dynamic-modal__inner--active'] ) }>
           {
-            ( active && renderComplated ) && <FocusTrapDynamicModal>{ children }</FocusTrapDynamicModal>
+            ( active && renderComplated ) && 
+              focusTrap ? <FocusTrapDynamicModal>{ children }</FocusTrapDynamicModal> :
+              children
           }
         </div>
       </div>


### PR DESCRIPTION
## 개요
이전 PR : https://github.com/dobby200ok/nklcb.net/pull/4#issue-3046834002
에서 발생된 사이드 이펙트, 포커스 트랩이 채용 공고 상세 페이지에서 딤드 레이어가 설정이 안된 상태에서
포커스 트랩이 적용됨에 따라 오류를 수정합니다.

## 설계 
dimmed 상태 값이 있는 경우에만 focusTrap을 활성화합니다.