### PR TITLE
feat : 등록일 일단위 -> 실시간 조정

### DIFF
--- a/src/components/molecules/JobCardItem/JobCardItem.tsx
+++ b/src/components/molecules/JobCardItem/JobCardItem.tsx
@@ -38,7 +38,7 @@ const JobCardItem:React.FC<JobListItemProps> = ({ _id, company, title, positionD
     }
 
     // @ desc : 공고의 등록일과 남은 기간을 문자열로 치환
-    const createDate = dateUtils.getTimeAgo( dateUtils.strToDate(date.create) );
+    const createDate = dateUtils.getTimeAgo( dateUtils.strToDate(date.create, date.createTime) );
 
     setCreateDt( createDate );
 

--- a/src/types/JobItemProps.ts
+++ b/src/types/JobItemProps.ts
@@ -40,6 +40,7 @@ export interface JobListItemProps {
     };
     infinity: boolean;
     create: string;
+    createTime: string;
   };
   summaryAI?: string | null;
 }


### PR DESCRIPTION
## 개요
채용 공고 리스트의 카드 아이템의 등록일이 일단위로 고정된 개발을 유지하였으나,
실시간으로 조정합니다.

## 설계 
DB의 도큐먼트에 각 크롤링된 시간을 추가 (05:13)
채용 공고 리스트의 등록일을 가공하는 utils 함수의 인자값에서 시간을 추가합니다.